### PR TITLE
Update Jquery.Plugin.UyghurInput.js

### DIFF
--- a/Jquery.Plugin.UyghurInput.js
+++ b/Jquery.Plugin.UyghurInput.js
@@ -6,8 +6,10 @@
 
 //jQuery plugin function
 $.fn.Uyghurinput = function () {
-    this.keypress(function () { naddchar(event) });
-    this.keydown(function () { proc_kd(event) });
+    //this.keypress(function () { naddchar(event) }); // work fine in chrome,ie but not in firefox
+    //this.keydown(function () { proc_kd(event) });  // because firefox have different event handler
+    this.keypress(function (e) { e = e||event;   naddchar(e) }); 
+    this.keydown(function (e) { e = e||event;  proc_kd(e) });
 };
 
 var imode = 0; // input mode, default is Uyghur


### PR DESCRIPTION
early version works fine chrome, IE but not in firefox, after changing the code the code compatible with both in ie dom , firefox dom based browser.

Ps; I am owner of Tildil.com, for input uyghur i use your jquery, and i have thanks to you and mr. muhemmed brother.  I hope you test and merge it with my change. Another problem is for internet user, we don't have to download jquery file, just use link <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script> like that, hope you add this to your readme file. thanks a lot, you save me a lot time, rexmet..
